### PR TITLE
Fix image path replacement in generator

### DIFF
--- a/src/app/posts/articles/first-post/page.tsx
+++ b/src/app/posts/articles/first-post/page.tsx
@@ -4,6 +4,6 @@ export const metadata = { title: "First Post", date: "2024-06-15T00:00:00.000Z" 
 
 export default function Page() {
   return (
-    <article className="prose mx-auto" dangerouslySetInnerHTML={{ __html: "<h1>My First Post</h1>\n<p>This is the <strong>first</strong> post in my static blog.</p>\n" }} />
+    <article className="prose mx-auto" dangerouslySetInnerHTML={{ __html: "<h1>My First Post</h1>\n<p>This is the <strong>first</strong> post in my static blog.\n<img src=\"/images/sample.png\" alt=\"hogea\"></p>\n" }} />
   );
 }

--- a/src/public/markdowns/first-post.md
+++ b/src/public/markdowns/first-post.md
@@ -6,3 +6,4 @@ date: 2024-06-15
 # My First Post
 
 This is the **first** post in my static blog.
+![hogea](../images/sample.png)

--- a/src/scripts/buildPosts.js
+++ b/src/scripts/buildPosts.js
@@ -27,7 +27,9 @@ function build() {
   for (const file of files) {
     const slug = file.replace(/\.md$/, '');
     const filePath = path.join(markdownDir, file);
-    const { data, content } = matter(fs.readFileSync(filePath, 'utf8'));
+    let { data, content } = matter(fs.readFileSync(filePath, 'utf8'));
+    // Replace relative image paths (../images/...) with absolute ones (/images/...)
+    content = content.replace(/\(\.\.\/images\//g, '(/images/');
     const html = marked.parse(content);
     const title = data.title || slug;
     const date = data.date || '';


### PR DESCRIPTION
## Summary
- convert `../images/` paths in markdown to `/images/` during generation

## Testing
- `npm run generate`

------
https://chatgpt.com/codex/tasks/task_e_68453efa47bc8327a33527800fa355cc